### PR TITLE
fix(Metrics): set Y-axis domain for CPU and Memory metrics charts

### DIFF
--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -430,6 +430,7 @@ export function Metrics() {
                 <YAxis 
                   stroke="#6B7280"
                   fontSize={12}
+                  domain={[0, 100]}
                   label={{ value: 'CPU %', angle: -90, position: 'insideLeft' }}
                 />
                 <Tooltip 
@@ -502,6 +503,7 @@ export function Metrics() {
                 <YAxis 
                   stroke="#6B7280"
                   fontSize={12}
+                  domain={[0, 100]}
                   label={{ value: 'Memory %', angle: -90, position: 'insideLeft' }}
                 />
                 <Tooltip 
@@ -700,6 +702,7 @@ export function Metrics() {
                   <YAxis 
                     stroke="#6B7280"
                     fontSize={12}
+                    domain={[0, 100]}
                     label={{ 
                       value: expandedChart === 'cpu' ? 'CPU %' : 'Memory %', 
                       angle: -90, 


### PR DESCRIPTION
- Updated Y-axis domain for CPU and Memory charts to range from 0 to 100 for improved data representation.
- Ensured consistent scaling across all relevant charts for better visual clarity.